### PR TITLE
Fix navigation offset duplication

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,11 +48,6 @@
 
         /* Ajuste de posición de los enlaces del menú */
         header nav div:last-child {
-            margin-left: -45px; /* Ajusta este valor para mover más a la izquierda */
-        }
-
-        /* Si quieres permitir ajustes más finos */
-        header nav div:last-child {
             position: relative;
             left: -45px; /* Cambia este valor para mover más a la izquierda o derecha */
         }


### PR DESCRIPTION
## Summary
- remove duplicate CSS rule that pushed navigation links too far left

## Testing
- `npx -y htmlhint index.html` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c27f5bec8322ba569dc4b6b7680f