### PR TITLE
Fix contact navigation overflow on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
             display: flex;
             align-items: center;
             margin-left: auto;
+            flex-wrap: wrap;
         }
 
         header nav a {
@@ -247,6 +248,16 @@
 
         /* Responsivo */
         @media (max-width: 768px) {
+            header nav {
+                flex-direction: column;
+                align-items: center;
+            }
+
+            header nav .nav-links {
+                flex-direction: column;
+                margin-left: 0;
+            }
+
             .habilidades, .proyectos-grid {
                 flex-direction: column;
                 align-items: center;


### PR DESCRIPTION
## Summary
- Ensure contact navigation link remains visible on narrow viewports by enabling flex wrap and adding mobile layout rules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a55ef16fe88322857d288b0697d052