### PR TITLE
Fix header width to keep contact link visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
             padding: 1rem;
             box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
             z-index: 1000;
+            box-sizing: border-box;
         }
 
         header nav {


### PR DESCRIPTION
## Summary
- ensure header includes padding inside its width so the contact link is not pushed off-screen

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a561de797483229b7fd5916e4d8863