### PR TITLE
Integrate Formspree contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,6 +231,11 @@
             background: #357ABD;
         }
 
+        #form-status {
+            margin-top: 1rem;
+            font-weight: bold;
+        }
+
         /* Footer */
         footer {
             background: #333;
@@ -329,12 +334,13 @@
     </section>
     <section class="contacto" id="contacto">
         <h2>Contacto</h2>
-        <form>
+        <form id="contact-form" action="https://formspree.io/f/mblawwyw" method="POST">
             <input type="text" name="nombre" placeholder="Tu nombre" required>
             <input type="email" name="email" placeholder="Tu correo electrónico" required>
             <textarea name="mensaje" rows="5" placeholder="Tu mensaje" required></textarea>
             <button type="submit">Enviar</button>
         </form>
+        <p id="form-status"></p>
     </section>
     <footer>
         <p>&copy; 2025 Iván Acosta. Todos los derechos reservados.</p>
@@ -356,6 +362,32 @@
                     }
                 });
             });
+
+            const form = document.getElementById('contact-form');
+            const status = document.getElementById('form-status');
+            if (form) {
+                form.addEventListener('submit', async (e) => {
+                    e.preventDefault();
+                    const data = new FormData(form);
+                    try {
+                        const response = await fetch(form.action, {
+                            method: form.method,
+                            body: data,
+                            headers: {
+                                'Accept': 'application/json'
+                            }
+                        });
+                        if (response.ok) {
+                            status.textContent = '¡Gracias por tu mensaje!';
+                            form.reset();
+                        } else {
+                            status.textContent = 'Oops! Hubo un problema al enviar tu mensaje.';
+                        }
+                    } catch (error) {
+                        status.textContent = 'Oops! Hubo un problema al enviar tu mensaje.';
+                    }
+                });
+            }
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- hook contact form to Formspree endpoint
- add status message style
- submit form via JavaScript and show feedback

## Testing
- `npm test` *(fails: enoent ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c1e6a9e30883228f5ebb67b705d061